### PR TITLE
fix(editorial): strengthen automatic post generation checks and admin editorial UI

### DIFF
--- a/.github/workflows/create-blog-draft-pr.yml
+++ b/.github/workflows/create-blog-draft-pr.yml
@@ -66,19 +66,27 @@ jobs:
           echo "=== Ficheiros na pasta drafts/ ==="
           ls -la scripts/editorial/drafts/ || echo "Pasta vazia"
 
-      - name: "✅ Validar ficheiro gerado"
+      - name: "📌 Resolver ficheiro gerado"
+        id: resolve-draft
         run: |
-          DRAFT_FILE=$(ls scripts/editorial/drafts/*.md | head -1)
+          DRAFT_FILE=$(find scripts/editorial/drafts -maxdepth 1 -type f -name '*.md' -print0 | xargs -0 ls -1t 2>/dev/null | head -n 1)
           if [ -z "$DRAFT_FILE" ]; then
             echo "❌ Nenhum ficheiro de draft encontrado!"
             exit 1
           fi
+
+          echo "draft_file=$DRAFT_FILE" >> "$GITHUB_OUTPUT"
+          echo "Draft resolvido: $DRAFT_FILE"
+
+      - name: "✅ Validar ficheiro gerado"
+        run: |
+          DRAFT_FILE="${{ steps.resolve-draft.outputs.draft_file }}"
           echo "A validar: $DRAFT_FILE"
           npx ts-node scripts/editorial/formatDraft.ts validate "$DRAFT_FILE"
 
       - name: "📊 Mostrar resumo do draft"
         run: |
-          DRAFT_FILE=$(ls scripts/editorial/drafts/*.md | head -1)
+          DRAFT_FILE="${{ steps.resolve-draft.outputs.draft_file }}"
           echo "=== RESUMO DO DRAFT GERADO ==="
           echo "Ficheiro: $DRAFT_FILE"
           wc -w "$DRAFT_FILE" | awk '{print "Palavras (aprox.):", $1}'

--- a/src/components/admin/AdminEditorial.tsx
+++ b/src/components/admin/AdminEditorial.tsx
@@ -1,30 +1,40 @@
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabaseClient";
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
 
 type BlogPost = {
   id: string;
   title: string;
+  slug: string;
   status: "draft" | "published";
+  author_name: string | null;
   created_at: string;
   updated_at: string;
   published_at: string | null;
-  views: number;
+  views: number | null;
 };
 
 const AdminEditorial = () => {
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [loading, setLoading] = useState(true);
+  const [processingId, setProcessingId] = useState<string | null>(null);
 
   const fetchPosts = async () => {
     setLoading(true);
 
     const { data, error } = await supabase
       .from("blog_posts")
-      .select("*")
+      .select("id,title,slug,status,author_name,created_at,updated_at,published_at,views")
       .order("created_at", { ascending: false });
 
     if (error) {
       console.error("Erro ao buscar posts:", error);
+      toast({
+        title: "Erro ao carregar posts",
+        description: "Não foi possível carregar os posts editoriais.",
+        variant: "destructive",
+      });
     } else {
       setPosts(data as BlogPost[]);
     }
@@ -33,6 +43,7 @@ const AdminEditorial = () => {
   };
 
   const approvePost = async (id: string) => {
+    setProcessingId(id);
     const { error } = await supabase
       .from("blog_posts")
       .update({
@@ -43,13 +54,18 @@ const AdminEditorial = () => {
 
     if (error) {
       console.error("Erro ao aprovar:", error);
+      toast({ title: "Erro ao aprovar", variant: "destructive" });
+      setProcessingId(null);
       return;
     }
 
-    fetchPosts();
+    toast({ title: "Post publicado", description: "O post está visível no blog." });
+    await fetchPosts();
+    setProcessingId(null);
   };
 
   const unpublishPost = async (id: string) => {
+    setProcessingId(id);
     const { error } = await supabase
       .from("blog_posts")
       .update({
@@ -60,10 +76,14 @@ const AdminEditorial = () => {
 
     if (error) {
       console.error("Erro ao despublicar:", error);
+      toast({ title: "Erro ao despublicar", variant: "destructive" });
+      setProcessingId(null);
       return;
     }
 
-    fetchPosts();
+    toast({ title: "Post movido para rascunho" });
+    await fetchPosts();
+    setProcessingId(null);
   };
 
   const deletePost = async (id: string) => {
@@ -77,24 +97,31 @@ const AdminEditorial = () => {
 
     if (error) {
       console.error("Erro ao eliminar:", error);
+      toast({ title: "Erro ao eliminar", variant: "destructive" });
       return;
     }
 
-    fetchPosts();
+    toast({ title: "Post eliminado" });
+    await fetchPosts();
   };
 
   useEffect(() => {
     fetchPosts();
   }, []);
 
-  const drafts = posts.filter((p) => p.status === "draft");
-  const published = posts.filter((p) => p.status === "published");
+  const drafts = useMemo(() => posts.filter((p) => p.status === "draft"), [posts]);
+  const published = useMemo(() => posts.filter((p) => p.status === "published"), [posts]);
 
   if (loading) return <div>Carregar...</div>;
 
   return (
     <div className="p-6 space-y-10">
-      <h1 className="text-2xl font-bold">Editorial</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Editorial</h1>
+        <Button variant="outline" onClick={fetchPosts} disabled={loading}>
+          Atualizar
+        </Button>
+      </div>
 
       {/* RASCUNHOS */}
       <section>
@@ -106,6 +133,8 @@ const AdminEditorial = () => {
             <thead>
               <tr className="border-b">
                 <th className="text-left p-2">Título</th>
+                <th className="text-left p-2">Slug</th>
+                <th className="p-2">Autor</th>
                 <th className="p-2">Criado</th>
                 <th className="p-2">Ações</th>
               </tr>
@@ -114,12 +143,15 @@ const AdminEditorial = () => {
               {drafts.map((post) => (
                 <tr key={post.id} className="border-b">
                   <td className="p-2">{post.title}</td>
+                  <td className="p-2 text-sm text-muted-foreground">{post.slug}</td>
+                  <td className="p-2">{post.author_name || "Equipa Keepla"}</td>
                   <td className="p-2">
                     {new Date(post.created_at).toLocaleDateString()}
                   </td>
                   <td className="p-2 space-x-2">
                     <button
-                      className="bg-green-600 text-white px-3 py-1 rounded"
+                      className="bg-green-600 text-white px-3 py-1 rounded disabled:opacity-50"
+                      disabled={processingId === post.id}
                       onClick={() => approvePost(post.id)}
                     >
                       Aprovar
@@ -148,6 +180,7 @@ const AdminEditorial = () => {
             <thead>
               <tr className="border-b">
                 <th className="text-left p-2">Título</th>
+                <th className="text-left p-2">Slug</th>
                 <th className="p-2">Publicado</th>
                 <th className="p-2">Views</th>
                 <th className="p-2">Ações</th>
@@ -157,6 +190,7 @@ const AdminEditorial = () => {
               {published.map((post) => (
                 <tr key={post.id} className="border-b">
                   <td className="p-2">{post.title}</td>
+                  <td className="p-2 text-sm text-muted-foreground">{post.slug}</td>
                   <td className="p-2">
                     {post.published_at
                       ? new Date(post.published_at).toLocaleDateString()
@@ -165,7 +199,8 @@ const AdminEditorial = () => {
                   <td className="p-2">{post.views ?? 0}</td>
                   <td className="p-2">
                     <button
-                      className="bg-yellow-600 text-white px-3 py-1 rounded"
+                      className="bg-yellow-600 text-white px-3 py-1 rounded disabled:opacity-50"
+                      disabled={processingId === post.id}
                       onClick={() => unpublishPost(post.id)}
                     >
                       Despublicar


### PR DESCRIPTION
### Motivation
- Ensure the automated draft→PR→sync flow is deterministic and robust when multiple drafts exist. 
- Fix and harden the Admin Editorial screen so it doesn’t break at runtime and provides clear UX for editorial actions.

### Description
- Updated admin component `src/components/admin/AdminEditorial.tsx` to use the correct Supabase client import (`@/integrations/supabase/client`) and to align the typed fields with the `blog_posts` table (added `slug`, `author_name`, nullable `views`).
- Improved editorial UI/UX by adding a refresh `Atualizar` button, in-flight action state (`processingId`) to disable publish/unpublish buttons while requests run, `toast` notifications for success/errors, and showing `slug` and `author` columns in both Drafts and Published lists.
- Hardened the GH Actions workflow `.github/workflows/create-blog-draft-pr.yml` to deterministically resolve the newly generated draft file (select latest `scripts/editorial/drafts/*.md`) and expose it via `GITHUB_OUTPUT` so subsequent validation and summary steps use the exact resolved file.
- Small performance/clarity tweaks: request projection when fetching posts (`.select("id,title,slug,status,author_name,created_at,updated_at,published_at,views")`) and use `useMemo` for draft/published lists.

### Testing
- Verified code changes via diffs and local file inspection (`git diff`, file content checks); those inspections succeeded.
- Attempted to run project lifecycle commands: `npm ci` failed due to environment restrictions (`403 Forbidden` against npm registry) so dependency install did not complete; therefore `npm run build` and `npm run dev` could not run (they failed due to missing packages like `vite` / `@typescript-eslint/parser`).
- Attempted to run editorial scripts (`npx ts-node scripts/editorial/selectTopic.ts list por_escrever` and validation flows) but those invocations failed in this environment because `ts-node` could not be fetched (`npm` registry 403), so runtime script checks were not possible here.
- Commit and local patch application were successful: changes staged and committed (`git commit`) and workflow + component changes were verified in the repo via diffs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998a76d98688324858f681d6db338ca)