### PR TITLE
Fix Tailwind PostCSS plugin configuration for production builds

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
### Motivation
- Fix the Vercel production build error caused by using `tailwindcss` directly as a PostCSS plugin because Tailwind v4 moved the PostCSS integration to a separate package (`@tailwindcss/postcss`).

### Description
- Update `postcss.config.js` to use `@tailwindcss/postcss` instead of `tailwindcss` by replacing `tailwindcss: {}` with `"@tailwindcss/postcss": {}`.

### Testing
- Ran `npm run build` locally to validate the change, but the process failed at the lint step with `Cannot find module '@typescript-eslint/parser'` and attempts to install the missing dependency were blocked by the npm registry (403), so the full production build could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699904ee8440832494b721508e0298fd)